### PR TITLE
java-interop: add extra properties to GreyhoundConfig

### DIFF
--- a/java-interop/src/main/java/com/wixpress/dst/greyhound/scala/GreyhoundConfig.scala
+++ b/java-interop/src/main/java/com/wixpress/dst/greyhound/scala/GreyhoundConfig.scala
@@ -7,12 +7,18 @@ import com.wixpress.dst.greyhound.future.GreyhoundRuntime
 import scala.collection.JavaConverters._
 
 class GreyhoundConfig(val bootstrapServers: String,
+                      val extraProperties: Map[String, String],
                       val runtime: GreyhoundRuntime) {
 
   def this(bootstrapServers: util.Set[String]) =
-    this(bootstrapServers.asScala.toSet.mkString(","), GreyhoundRuntime.Live)
+    this(bootstrapServers.asScala.toSet.mkString(","), Map.empty, GreyhoundRuntime.Live)
+
+  def this(bootstrapServers: util.Set[String], extraProperties: java.util.Map[String, String]) =
+    this(bootstrapServers.asScala.toSet.mkString(","), extraProperties.asScala.toMap, GreyhoundRuntime.Live)
 
   def this(bootstrapServers: String) =
-    this(bootstrapServers, GreyhoundRuntime.Live)
+    this(bootstrapServers, Map.empty, GreyhoundRuntime.Live)
 
+  def this(bootstrapServers: String, extraProperties: java.util.Map[String, String]) =
+    this(bootstrapServers, extraProperties.asScala.toMap, GreyhoundRuntime.Live)
 }

--- a/java-interop/src/main/java/com/wixpress/dst/greyhound/scala/GreyhoundConsumersBuilder.scala
+++ b/java-interop/src/main/java/com/wixpress/dst/greyhound/scala/GreyhoundConsumersBuilder.scala
@@ -30,7 +30,7 @@ class GreyhoundConsumersBuilder(val config: GreyhoundConfig) {
       executor = createExecutor
       makeConsumer = ZManaged.foreach(handlers(executor, runtime)) { case (group, javaConsumerConfig) =>
         import javaConsumerConfig._
-        RecordConsumer.make(RecordConsumerConfig(config.bootstrapServers, group, Topics(initialTopics), offsetReset = offsetReset, retryConfig = retryConfig), handler)
+        RecordConsumer.make(RecordConsumerConfig(config.bootstrapServers, group, Topics(initialTopics), offsetReset = offsetReset, retryConfig = retryConfig, extraProperties = config.extraProperties), handler)
       }
       reservation <- makeConsumer.reserve
       consumers <- reservation.acquire

--- a/java-interop/src/main/java/com/wixpress/dst/greyhound/scala/GreyhoundProducerBuilder.scala
+++ b/java-interop/src/main/java/com/wixpress/dst/greyhound/scala/GreyhoundProducerBuilder.scala
@@ -16,7 +16,7 @@ class GreyhoundProducerBuilder(val config: GreyhoundConfig) {
   def build: GreyhoundProducer = config.runtime.unsafeRun {
     for {
       runtime <- ZIO.runtime[Env]
-      producerConfig = ProducerConfig(config.bootstrapServers)
+      producerConfig = ProducerConfig(config.bootstrapServers, extraProperties = config.extraProperties)
       makeProducer = Producer.makeR[Any](producerConfig)
       reservation <- makeProducer.reserve
       producer <- reservation.acquire


### PR DESCRIPTION
- Modify GreyhoundConfig to accept extraProperties map parameter.
- Add Unit test case (`GreyhoundBuilderTest.configure_consumer_with_timeout_custom_props`) but it is still failing; seem like properties setting doesn't have any affect on kafka consumer/producer. Please help to verify this.