### PR TITLE
ZIO Magic Reproducible Bug

### DIFF
--- a/greyhoundsidecar/src/test/scala/greyhound/SidecarServiceTest.scala
+++ b/greyhoundsidecar/src/test/scala/greyhound/SidecarServiceTest.scala
@@ -58,12 +58,15 @@ object SidecarServiceTest extends JUnitRunnableSpec with KafkaTestSupport with C
           records = requests.head.records
         } yield assert(records.size)(equalTo(2))
       },
-    ).provideLayer(
-      TestContext.layer ++
-        ZLayer.succeed(zio.Scope.global) ++
-        TestSidecarUser.layer ++
-        (TestSidecarUser.layer >>> sidecarUserServerLayer) ++
-        ((ConsumerRegistryLive.layer ++ RegisterLive.layer ++ TestKafkaInfo.layer) >>> SidecarService.layer)) @@
+    ).provide(
+      TestContext.layer,
+      ZLayer.succeed(zio.Scope.global),
+      TestSidecarUser.layer,
+      sidecarUserServerLayer,
+      ConsumerRegistryLive.layer,
+      RegisterLive.layer,
+      TestKafkaInfo.layer,
+      SidecarService.layer) @@
       TestAspect.withLiveClock @@
       runKafka(kafkaPort, zooKeeperPort) @@
       sequential


### PR DESCRIPTION
When using `provide` method to build the dependency tree automatically, the tests are flaky (the actual failing reason is that one of the [Ref] that we use is empty, i.e `consume topic` tests fails as it expects the ref to be non empty).

It looks like some layers are shared between tests/ leaking between tests, or something similar.

When using `provideLayer`, and building the dependency tree manually everything is working (this is the logic at the moment in master).