### PR TITLE
Introduce Bazel Steward - a tool for keeping dependencies up to date in Bazel

### DIFF
--- a/.github/workflows/bazel-steward.yaml
+++ b/.github/workflows/bazel-steward.yaml
@@ -1,0 +1,15 @@
+name: Bazel Steward
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  bazel-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: VirtusLab/bazel-steward@latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.class
 *.log
 bazel-*
+!bazel-steward.yaml
 .idea
 *.iml
 *.pyc

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,18 +9,34 @@ http_archive(
     name = "bazel_skylib",
     sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
     type = "tar.gz",
-    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib.{}.tar.gz".format(skylib_version, skylib_version),
+    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
 )
 
 load("//dependencies/google_protobuf:google_protobuf.bzl", "google_protobuf")
 
 google_protobuf()
 
-load("@greyhound//central-sync:dependencies.bzl", "rules_jvm_external", "rules_kotlin", "vaticle_bazel_distribution")
+load("@greyhound//central-sync:dependencies.bzl", "rules_kotlin", "vaticle_bazel_distribution")
 
 rules_kotlin()
 
-rules_jvm_external()
+RULES_JVM_EXTERNAL_TAG = "5.2"
+RULES_JVM_EXTERNAL_SHA ="f86fd42a809e1871ca0aabe89db0d440451219c3ce46c58da240c7dcdc00125f"
+
+http_archive(
+    name = "rules_jvm_external",
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/%s/rules_jvm_external-%s.tar.gz" % (RULES_JVM_EXTERNAL_TAG, RULES_JVM_EXTERNAL_TAG)
+)
+
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
+rules_jvm_external_deps()
+
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
+rules_jvm_external_setup()
 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 
@@ -31,17 +47,6 @@ kt_register_toolchains()
 vaticle_bazel_distribution()
 
 load("@vaticle_bazel_distribution//maven:deps.bzl", "maven_artifacts_with_versions")
-
-RULES_JVM_EXTERNAL_TAG = "3.1"
-
-RULES_JVM_EXTERNAL_SHA = "e246373de2353f3d34d35814947aa8b7d0dd1a58c2f7a6c41cfeaff3007c2d14"
-
-http_archive(
-    name = "rules_jvm_external",
-    sha256 = RULES_JVM_EXTERNAL_SHA,
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
-)
 
 load("//:third_party.bzl", "dependencies")
 

--- a/central-sync/dependencies.bzl
+++ b/central-sync/dependencies.bzl
@@ -16,11 +16,3 @@ def rules_kotlin():
         strip_prefix = "rules_kotlin-c2519b00299cff9df22267e8359784e9948dba67",
         sha256 = "1455f2ec4bf7ea12d2c90b0dfd6402553c3bb6cbc0271023e2e01ccdefb4a49a",
     )
-
-def rules_jvm_external():
-    http_archive(
-        name = "rules_jvm_external",
-        strip_prefix = "rules_jvm_external-3.2",
-        sha256 = "82262ff4223c5fda6fb7ff8bd63db8131b51b413d26eb49e3131037e79e324af",
-        url = "https://github.com/bazelbuild/rules_jvm_external/archive/3.2.zip",
-    )


### PR DESCRIPTION
Hello everyone,

As one of developers I am submitting this pull request to introduce our new tool for Bazel repositories. [Bazel Steward](https://github.com/VirtusLab/bazel-steward) simplifies the process of checking and updating dependencies in your Bazel projects, making it more efficient to keep them up-to-date.
We hope that this tool will be useful to the Bazel community, and we look forward to your feedback.

This pull request integrates Bazel Steward through Github Actions which is currently the easiest way to do this. It will run every day at 12 and create new PRs or resolve conflicts on existing if necessary. You can preview how it looks in [a fork](https://github.com/lukaszwawrzyk/greyhound/pulls) that I used to test it. For more details, you can check [the project readme](https://github.com/VirtusLab/bazel-steward#readme).

Bazel Steward is able to correctly update all your maven dependencies and version of Bazel itself. Support for updating rules works in many cases, but we are still working on it to make it more robust. In order to make it work.

We hope that Bazel Steward will make it easier for you to manage dependencies. If you encounter any issues or have any feedback, please don't hesitate to reach out to us. Thank you!


-----

Changes:
* added GitHub Action Workflow for Bazel Steward
* Made skylib url explicit - so that Bazel Steward can replace it (maintainers of skylib changed artifact naming scheme and it is not enough to just replace the version)
* updated rules_jvm_external to 5.2. Version 4.0+ is required for Bazel Steward to work with Maven dependencies. Also note that you had your rules_jvm_external defined twice (once in a function and once explicitly), now it is defined once. I put it in the WORKSPACE file, because otherwise Bazel Steward is not able to detect it. We plan to support this scenario in the future
* Excluded bazel-steward.yaml to `.gitignore`. It will make your life easier if you choose to configure Bazel Steward further